### PR TITLE
Adds OpenSUSE support and updates hipreport.sh script

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Need to connect your Linux desktop to a GlobalProtect VPN, but your company uses
 
 ## "Supported" Distros
 
-This script was tested on Xubuntu 19.10 and CentOS 8. Only Xubuntu "works" but CentOS 8 is nearly working. This is all unsupported. YMMV.
+This script was tested on Xubuntu 19.10, CentOS 8 and OpenSUSE Tumbleweed. Only Xubuntu and OpenSUSE "works" but CentOS 8 is nearly working. This is all unsupported. YMMV.
 
 ## Installation
 
@@ -44,3 +44,4 @@ Run `stop.sh`. Or kill the running openconnect process. Whatever.
 * CentOS 8 almost works, but DNS is to be an issue. I don't know why.
 * No NetworkManager integration yet, and it doesn't look good.
 * Some Gnome Shell installations may require gnome-tweaks to actually enable the indicator applet.
+* If you use i3wm as your window manager, please make sure to run `pkttyagent --process $$ &` before calling `openconnect` command inside either `start.sh` and `stop.sh` files.  

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Tested on Xubuntu 19.10 and CentOS 8
+# Tested on Xubuntu 19.10, CentOS 8 and OpenSUSE Tumbleweed
 
 set -e
 
@@ -23,7 +23,11 @@ function install_gp_saml_gui {
 }
 
 function install_hipreport {
-    HIPREPORT_SRC='https://raw.githubusercontent.com/dlenski/openconnect/master/hipreport.sh'
+    # We are not using the master branch because the project was deprecated.
+    # This is the most recent version of the hipreport.sh file.
+    # TODO: We should review how to procceed once this project has been
+    # deprecated. Maybe add this hipreport to our project.
+    HIPREPORT_SRC='https://raw.githubusercontent.com/dlenski/openconnect/034dba1b6e365e76aa1b05f6a0f6f0fcd206e38f/hipreport.sh'
     HIPREPORT_SCRIPT=/usr/libexec/openconnect/hipreport.sh
     # mkdir for sources, if not available
     if [ ! -d /usr/libexec/openconnect ]; then

--- a/install.sh
+++ b/install.sh
@@ -60,8 +60,19 @@ if [ "" = "${VPN_SERVER}" ]; then
     >&2 echo "VPN Server not set. Edit /etc/gp-okta.conf before starting VPN."
 fi
 
+# OpenSUSE distribution. Keep this if block as the first one
+# because OpenSUSE often creates a link for 'apt' command pointing to
+# zypper. It would fall into the Ubuntu 'if' block below by mistake.
+if ! [[ $(command -v "zypper") = "" ]]; then
+    zypper refresh
+    zypper install --no-confirm \
+           git wget openconnect python3-gobject python3-lxml python3-requests
+    install_conf "${VPN_SERVER}"
+    install_hipreport
+    install_gp_saml_gui
+
 # ubuntu
-if ! [[ $(command -v "apt") = "" ]]; then
+elif ! [[ $(command -v "apt") = "" ]]; then
     apt update
     apt -y install \
         git wget openconnect \
@@ -70,6 +81,7 @@ if ! [[ $(command -v "apt") = "" ]]; then
     install_conf "${VPN_SERVER}"
     install_hipreport
     install_gp_saml_gui
+
 # centos
 elif ! [[ $(command -v "yum") = "" ]]; then
     yum -y update
@@ -79,8 +91,9 @@ elif ! [[ $(command -v "yum") = "" ]]; then
     install_conf "${VPN_SERVER}"
     install_hipreport
     install_gp_saml_gui
+
 # unknown
 else
-    >&2 echo "You are not running a Debian/Red Hat derivative. Sorry."
+    >&2 echo "You are not running a Debian/Red Hat/OpenSUSE derivative. Sorry."
     exit 1
 fi


### PR DESCRIPTION
This Pull Request has the  following contributions:

- Adds installation support for OpenSUSE Linux distribution;
- Updates the URL used to fetch `hipreport.sh` script; 

Please, take a look at [dlenski/openconnect project](https://github.com/dlenski/openconnect) that says it was deprecated. It was made 6 days ago. They removed basically all files from the repository leaving only Readme behind for historical reasons.

I left a TODO comment on the code suggesting that, maybe, we should add the `hipreport.sh` to this project version control since the original one were deprecated. As you will see, the url is getting the last valid commit hash that has the script available. 

Hope that this Pull Request helps in something.